### PR TITLE
fix bug when using encoding

### DIFF
--- a/P4.py
+++ b/P4.py
@@ -590,6 +590,9 @@ class P4(P4API.P4Adapter):
             setattr(self, k, v)
                 
         flatArgs = self.__flatten(args)
+
+        if self.logger:
+            self.logger.info("p4 " + " ".join(flatArgs))
         
         # if encoding is set, translate to Bytes
         if hasattr(self,"encoding") and self.encoding and not self.encoding == 'raw':
@@ -600,9 +603,6 @@ class P4(P4API.P4Adapter):
                 else:
                     result.append(s)
             flatArgs = result
-        
-        if self.logger:
-            self.logger.info("p4 " + " ".join(flatArgs))
         
         try:
             result = P4API.P4Adapter.run(self, *flatArgs)


### PR DESCRIPTION
when using `encoding`  and `logger` in P4, this line will raise an exception, because the type of item in `flatArgs` is `bytes`, but `bytes` has no `join`.
```
self.logger.info("p4 " + " ".join(flatArgs))
```
so, we can initialize the logger after encoding