### PR TITLE
Make P4Exception pickleable

### DIFF
--- a/P4.py
+++ b/P4.py
@@ -66,6 +66,13 @@ class P4Exception(Exception):
             self.value = value
     def __str__(self):
         return str(self.value)
+    
+    def __reduce__(self):
+        if hasattr(self, 'errors'):
+            return (self.__class__, ((self.value, self.errors, self.warnings),))
+        return (self.__class__, (self.value, ))
+            
+
 
 class Spec(dict):
     """Subclass of dict, representing the fields of a spec definition.


### PR DESCRIPTION
I'm using P4API alongside multiprocessing so that if the login hangs, I can time it out and terminate it it. I've observed that when the p4 login fails in the other process, the exception doesn't cross the process boundary and get rethrown in the parent because it fails to unpickle. 

I implemented `__reduce__` to make the object pickleable. There are probably other ways also, like removing the superclass __init__. 

Tested like this
```
    # single string case
    e = P4Exception(("one"))
    print(f"before: {e}")
    p = pickle.dumps(e)
    e_unpickled = pickle.loads(p)
    print(f"after: {e_unpickled}")


    # the multiple value case
    e = P4Exception(("one", "two","three"),)
    print(f"before: {e.value} | {e.errors} | {e.warnings}")
    p = pickle.dumps(e)
    e_unpickled = pickle.loads(p)
    print(f"after: {e_unpickled.value} | {e_unpickled.errors} | {e_unpickled.warnings}")

```

Before:
```
Traceback (most recent call last):
  File "/workspaces/p4python/./repro.py", line 15, in <module>
    main()
  File "/workspaces/p4python/./repro.py", line 11, in main
    e_unpickled = pickle.loads(p)
TypeError: P4Exception.__init__() missing 1 required positional argument: 'value'

```
After:
```
before: one
after: one
before: one | two | three
after: one | two | three
```

Also end to end tested in my application - with this fix, the exceptions get marshalled across the process boundary and rethrown in my code. 