### PR TITLE
Adds support for aarch64 architecture in PlatformInfo.py

### DIFF
--- a/tools/PlatformInfo.py
+++ b/tools/PlatformInfo.py
@@ -182,6 +182,8 @@ class PlatformInfo:
             return 'SPARC'
         elif re.match('arm.*', str):
             return "ARM"
+        elif re.match('aarch.*', str):
+            return "ARM"
 
     def get_ssl_ver(self, ssl_ver_string):
         pattern = re.compile(r"(\d+)\.(\d+).(\d+).*")


### PR DESCRIPTION
... when running `pip install p4python` in Ubuntu 22.04 docker on Mac M1

Fixes:
```
        File "/tmp/pip-install-sl7objny/p4python_0d6b62bf004a457fb76a0cb4b95ccf64/setup.py", line 347, in run
          info = PlatformInfo(apiVersion, releaseVersion, str(p4_ssl_dir), p4_ssl_ver)
        File "/tmp/pip-install-sl7objny/p4python_0d6b62bf004a457fb76a0cb4b95ccf64/tools/PlatformInfo.py", line 144, in __init__
          self.ID_OS = self.inStr(unix + release + arch)
      TypeError: can only concatenate str (not "NoneType") to str
```