### PR TITLE
Added detection for aarch64 to be picked up as ARM

### DIFF
--- a/tools/PlatformInfo.py
+++ b/tools/PlatformInfo.py
@@ -180,7 +180,7 @@ class PlatformInfo:
             return 'X86_64'
         elif str == 'sparc':
             return 'SPARC'
-        elif re.match('arm.*', str):
+        elif re.match('arm.*', str) or str =='aarch64':
             return "ARM"
 
     def get_ssl_ver(self, ssl_ver_string):


### PR DESCRIPTION
When trying to install the library inside an arm64 docker container that uses `aarch64` as the architecture name instead of `arm64`, the package crashes since it does not handle detecting `aarch64` as ARM.
 
I've modified the check where it crashes to handle this.