### PR TITLE
Fixed exception on joining non-string element in run args

### DIFF
--- a/P4.py
+++ b/P4.py
@@ -615,7 +615,7 @@ class P4(P4API.P4Adapter):
         flatArgs = self.__flatten(args)
 
         if self.logger:
-            self.logger.info("p4 " + " ".join(flatArgs))
+            self.logger.info("p4 " + " ".join(str(x) for x in flatArgs))
         
         # if encoding is set, translate to Bytes
         if hasattr(self,"encoding") and self.encoding and not self.encoding == 'raw':


### PR DESCRIPTION
If a non-string argument is passed to run (like an `int` changelist number), the join will cause an exception to be thrown (when a logger has been set--if no logger is set, the command will succeed as the rest of the source is able to handle non-string arguments)

Repro:

```
import logging
from P4 import P4

logging.basicConfig(level="DEBUG")
logger = logging.getLogger()

p4 = P4()
p4.logger = logger
p4.encoding = "utf-8" # Optional

changelist = 123456

p4.connect()
p4.run_describe(changelist)
p4.disconnect()
```

Result:

```
  File "C:\Users\XXXXXXXX\AppData\Local\Programs\Python\Python312\Lib\site-packages\P4.py", line 500, in <lambda>
    return lambda *args, **kargs: self.run(cmd, *args, **kargs)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXXXXXXX\AppData\Local\Programs\Python\Python312\Lib\site-packages\P4.py", line 598, in run
    self.logger.info("p4 " + " ".join(flatArgs))
                             ^^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, int found
```